### PR TITLE
service: init version service

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -305,6 +305,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "79cf74a34b9b0cd91ee7d90e8b6b50fe7393a400a4f2209b5f6cb0434928ec6b"
+  inputs-digest = "b78500167334124213a521b9c2a98f423f61707990e5482f57bc91e7ec1c0668"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -41,6 +41,10 @@
   branch = "master"
   name = "github.com/giantswarm/micrologger"
 
+[[constraint]]
+  branch = "master"
+  name = "github.com/giantswarm/versionbundle"
+
 [prune]
   go-tests = true
   unused-packages = true

--- a/service/service.go
+++ b/service/service.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 
 	"github.com/giantswarm/microendpoint/service/version"
+	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 	"github.com/spf13/viper"
 
@@ -29,7 +30,27 @@ type Service struct {
 }
 
 func New(config Config) (*Service, error) {
+	var err error
+
+	var versionService *version.Service
+	{
+		versionConfig := version.Config{
+			Description:    config.Description,
+			GitCommit:      config.GitCommit,
+			Name:           config.ProjectName,
+			Source:         config.Source,
+			VersionBundles: newVersionBundles(),
+		}
+
+		versionService, err = version.New(versionConfig)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
 	s := &Service{
+		Version: versionService,
+
 		bootOnce: new(sync.Once),
 	}
 

--- a/service/version_bundles.go
+++ b/service/version_bundles.go
@@ -1,0 +1,9 @@
+package service
+
+import (
+	"github.com/giantswarm/versionbundle"
+)
+
+func newVersionBundles() []versionbundle.Bundle {
+	return []versionbundle.Bundle{}
+}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/2762

versionbundle was already vendored as transitive dependency of microkit.

```
$ go run ./main.go version
description: The extservice-operator manages connections from the guest cluster pods
  to the guest cluster services.
gitCommit: n/a
name: extservice-operator
source: https://github.com/giantswarm/extservice-operator
goVersion: go1.10
os: darwin
arch: amd64
versionBundles: []
```